### PR TITLE
Add Travis CI as Build Server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: csharp
-mono: none
+mono: latest
 dotnet: 2.0.0-preview2-006497
 dist: trusty
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: csharp
+solution: PullRequestsViewer.sln
+script:
+  - ./build.sh -c Release

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,5 @@ mono: none
 dotnet: 2.0.0-preview2-006497
 dist: trusty
 script:
+  - dotnet --version
   - ./build.sh -c Release

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: csharp
-solution: PullRequestsViewer.sln
+mono: none
+dotnet: 2.0.0-preview2-006497
+dist: trusty
 script:
   - ./build.sh -c Release

--- a/PullRequestsViewer.sln
+++ b/PullRequestsViewer.sln
@@ -26,6 +26,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{F53E7105-F
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{B55CE421-62A3-43C4-B4BC-D7EDC6AE03E1}"
 	ProjectSection(SolutionItems) = preProject
+		.travis.yml = .travis.yml
 		appveyor.yml = appveyor.yml
 		build.cake = build.cake
 		build.ps1 = build.ps1

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This project aims developers, who struggle to manage the PR's from several repos. When we work as a team, it's normal to stack some PR's, and sometimes we lost track of it. The Pull Requests Viewer allows a holistic view over the *open* PR's for the selected repos.
 
-[![Build status](https://ci.appveyor.com/api/projects/status/1is7xrovhnau8l0u?svg=true)](https://ci.appveyor.com/project/joaoasrosa/pullrequests-viewer)
+[![Build status](https://ci.appveyor.com/api/projects/status/1is7xrovhnau8l0u?svg=true)](https://ci.appveyor.com/project/joaoasrosa/pullrequests-viewer) [![Build Status](https://travis-ci.org/joaoasrosa/pullrequests-viewer.svg?branch=master)](https://travis-ci.org/joaoasrosa/pullrequests-viewer)
 
 ## Getting Started
 

--- a/build.cake
+++ b/build.cake
@@ -105,20 +105,25 @@ Task("GitVersion")
     .Description("Set the SemVer to the solution.")
     .Does(() =>
 	{
-	try{
-		gitVersion = GitVersion(new GitVersionSettings {
-			UpdateAssemblyInfo = true
-		});
+		try
+		{
+			gitVersion = GitVersion(new GitVersionSettings {
+				UpdateAssemblyInfo = true
+			});
 
-	    var file = File(projectPath);
-	    XmlPoke(file, "/Project/PropertyGroup/AssemblyVersion", gitVersion.MajorMinorPatch);
-		XmlPoke(file, "/Project/PropertyGroup/FileVersion", gitVersion.MajorMinorPatch);
-		XmlPoke(file, "/Project/PropertyGroup/Version", gitVersion.FullSemVer);
+			var file = File(projectPath);
+			XmlPoke(file, "/Project/PropertyGroup/AssemblyVersion", gitVersion.MajorMinorPatch);
+			XmlPoke(file, "/Project/PropertyGroup/FileVersion", gitVersion.MajorMinorPatch);
+			XmlPoke(file, "/Project/PropertyGroup/Version", gitVersion.FullSemVer);
 
-		Verbose("Full SemVer: " + gitVersion.FullSemVer);
-		Verbose("Major Minor Patch: " + gitVersion.MajorMinorPatch);
+			Verbose("Full SemVer: " + gitVersion.FullSemVer);
+			Verbose("Major Minor Patch: " + gitVersion.MajorMinorPatch);
 		}
-		catch(Exception ex){Verbose(ex.Message);}
+		catch(Exception ex)
+		{
+			// TODO: Travis CI fail here. Perhaps Cake problems. Investigate later.
+			Verbose(ex.Message);
+		}
 	});
 
 Task("Build")

--- a/build.cake
+++ b/build.cake
@@ -105,6 +105,7 @@ Task("GitVersion")
     .Description("Set the SemVer to the solution.")
     .Does(() =>
 	{
+	try{
 		gitVersion = GitVersion(new GitVersionSettings {
 			UpdateAssemblyInfo = true
 		});
@@ -116,6 +117,8 @@ Task("GitVersion")
 
 		Verbose("Full SemVer: " + gitVersion.FullSemVer);
 		Verbose("Major Minor Patch: " + gitVersion.MajorMinorPatch);
+		}
+		catch(Exception ex){Verbose(ex.Message);}
 	});
 
 Task("Build")


### PR DESCRIPTION
This PR adds the configuration for Travis CI. Also, improves the documentation and implement a workaround for the GitVersion Cake step (fails on TravisCI)